### PR TITLE
Add clear screen from cursor down, and from cursor up

### DIFF
--- a/src/gfx.c
+++ b/src/gfx.c
@@ -980,16 +980,18 @@ void gfx_term_restore_cursor()
 void gfx_term_clear_till_end()
 {
     gfx_swap_fg_bg();
-    gfx_fill_rect( (ctx.term.cursor_col+1) * ctx.term.FONTWIDTH, ctx.term.cursor_row * ctx.term.FONTWIDTH, ctx.W, ctx.term.FONTHEIGHT );
+    gfx_fill_rect( ctx.term.cursor_col * ctx.term.FONTWIDTH, ctx.term.cursor_row * ctx.term.FONTHEIGHT, ctx.W, ctx.term.FONTHEIGHT );
     gfx_swap_fg_bg();
+    gfx_term_render_cursor();
 }
 
 
 void gfx_term_clear_till_cursor()
 {
     gfx_swap_fg_bg();
-    gfx_fill_rect( 0, ctx.term.cursor_row * ctx.term.FONTHEIGHT, ctx.term.cursor_col * ctx.term.FONTWIDTH, ctx.term.FONTHEIGHT );
+    gfx_fill_rect( 0, ctx.term.cursor_row * ctx.term.FONTHEIGHT, (ctx.term.cursor_col+1) * ctx.term.FONTWIDTH, ctx.term.FONTHEIGHT );
     gfx_swap_fg_bg();
+    gfx_term_render_cursor();
 }
 
 
@@ -1006,6 +1008,28 @@ void gfx_term_clear_screen()
 {
     gfx_clear();
     gfx_term_render_cursor();
+}
+
+void gfx_term_clear_screen_from_here()
+{
+    if ( ctx.term.cursor_row < (ctx.term.HEIGHT-1) )
+    {
+        gfx_swap_fg_bg();
+        gfx_fill_rect( 0, (ctx.term.cursor_row+1) * ctx.term.FONTHEIGHT, ctx.W, ctx.H );
+        gfx_swap_fg_bg();
+    }
+    gfx_term_clear_till_end();
+}
+
+void gfx_term_clear_screen_to_here()
+{
+    if ( ctx.term.cursor_row > 0 )
+    {
+        gfx_swap_fg_bg();
+        gfx_fill_rect( 0, 0, ctx.W, ctx.term.cursor_row * ctx.term.FONTHEIGHT );
+        gfx_swap_fg_bg();
+    }
+    gfx_term_clear_till_cursor();
 }
 
 /** Set the font. */
@@ -1213,7 +1237,11 @@ int state_fun_final_letter( char ch, scn_state *state )
             break;
 
         case 'K':
-            if( state->cmd_params_size== 1 )
+            if( state->cmd_params_size== 0 )
+            {
+                gfx_term_clear_till_end();
+            }
+            else if( state->cmd_params_size== 1 )
             {
                 switch(state->cmd_params[0] )
                 {
@@ -1234,10 +1262,27 @@ int state_fun_final_letter( char ch, scn_state *state )
             break;
         
         case 'J':
-            if( state->cmd_params_size==1 && state->cmd_params[0] ==2 )
+            if( state->cmd_params_size== 0 )
             {
-                gfx_term_move_cursor(0,0);
-                gfx_term_clear_screen();
+                gfx_term_clear_screen_from_here();
+            }
+            else if( state->cmd_params_size== 1 )
+            {
+                switch(state->cmd_params[0] )
+                {
+                    case 0:
+                        gfx_term_clear_screen_from_here();
+                        goto back_to_normal;
+                    case 1:
+                        gfx_term_clear_screen_to_here();
+                        goto back_to_normal;
+                    case 2:
+                        gfx_term_move_cursor(0,0);
+                        gfx_term_clear_screen();
+                        goto back_to_normal;
+                    default:
+                        goto back_to_normal;
+                }
             }
             goto back_to_normal;
             break;

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -68,6 +68,8 @@ extern void gfx_term_clear_till_end();
 extern void gfx_term_clear_till_cursor();
 extern void gfx_term_clear_line();
 extern void gfx_term_clear_screen();
+extern void gfx_term_clear_screen_from_here();
+extern void gfx_term_clear_screen_to_here();
 extern void gfx_term_set_font(int width, int height);
 extern void gfx_term_set_tabulation(int width);
 


### PR DESCRIPTION
Fix clear line left and right of cursor to include the space the cursor
is on.  This mimics what XTerm does.  Also fixes incorrect calculation
where FONTWIDTH was used instead of FONTHEIGHT.

Make [J and [K do the same as [0J and [0K

Tested on RC2014 with GFX_USE_DMA set to OFF.  DMA causes a lot of
cursor artifacts.